### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Often while developing an app, We ran into a condition when we need to scale images to each and every aspect ratios for icons and other assets, and game will not end up here, after converting to all ratios we need to drag and drop each and every image to **XCAssets** file and put their as per ratios 😫😫😫
 
-##So time to say no to this: 😎😎😎
+## So time to say no to this: 😎😎😎
 
 **AVXCAssets Generator** takes path for your assets images and creates appiconset and imageset for you in just one click, **GIVE ONE GET ALL**
 
@@ -25,7 +25,7 @@ Contributing
 Have idea to add something new & exciting? you can always create pull request.
 
 
-##Author
+## Author
 [Angel Vasa](https://github.com/angelvasa)
 
 If you have any suggestions or any feedback, You can send your valueable feedback on Twitter **[angel_vasa](https://twitter.com/angel_vasa)** or you can mail me at: **vasaangel91@gmail.com**


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
